### PR TITLE
Fixed zoom value for IE8+.

### DIFF
--- a/detect-zoom.js
+++ b/detect-zoom.js
@@ -58,9 +58,10 @@ var DetectZoom = {
     // TODO: MSDN says that logicalXDPI and deviceXDPI existed since IE6
     // (which didn't even have whole-page zoom). Check to see whether
     // this method would also work in IE7.
+    var zoom = screen.deviceXDPI / screen.logicalXDPI;
     return {
-      zoom: screen.systemXDPI / screen.logicalXDPI,
-      devicePxPerCssPx: screen.deviceXDPI / screen.logicalXDPI
+      zoom: zoom,
+      devicePxPerCssPx: zoom
     };
   },
   _zoomWebkitMobile: function() {


### PR DESCRIPTION
When zooming systemXDPI and logicalXDPI keep the same value so the zoom
was always 1. Use deviceXDPI instead.
Tested with IE8-9 under XP and W7.
