### PR TITLE
Fixing issue with Opera zoom level when inside an IFrame

### DIFF
--- a/detect-zoom.js
+++ b/detect-zoom.js
@@ -177,7 +177,7 @@
      * @private
      */
     var opera11 = function () {
-        var zoom = window.outerWidth / window.innerWidth;
+        var zoom = window.top.outerWidth / window.top.innerWidth;
         zoom = Math.round(zoom * 100) / 100;
         return {
             zoom: zoom,


### PR DESCRIPTION
When inside of an IFrame in Opera, there is a mismatch between the frame what `window.outerWidth` and `window.innerWidth` are referencing. `window.outerWidth` seems to always reference the top window (the actual browser size) while `window.innerWidth` references the current window.

So, for example, when inside a 300px width IFrame with the browser at 1024px and at zoom of 1, `window.outerWidth` will be 1024 but `window.innerWidth` will be 300, meaning the zoom is currently detected to be 3.41333333333333 instead of 1.

By switching the references to always reference the top window, we avoid this mismatch of frames. I did a quick test of a cross domain iframe and there isn't any security warnings or errors when getting the dimensions of the top window.
