### PR TITLE
Simple Demo page, and thought for Chrome zoom detection fix

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -1,0 +1,15 @@
+<html>
+<body>
+<script src="./detect-zoom.js" type="text/javascript"></script>
+<script type="text/javascript">
+
+window.onresize = 
+window.onload = function() {
+	document.body.innerHTML  = "zoom: " + detectZoom.zoom();
+	document.body.innerHTML += "<br>";
+	document.body.innerHTML += "devicePxPerCssPx: " + detectZoom.device();
+};
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
The demo page is kinda silly, but it serves the purpose of testing quickly.

Also, for 27+ chrome detection:

var n = window.top.outerWidth / window.top.innerWidth; 
var zoom = Math.round(n * 100) / 100;

This seems to work perfectly.

It should be tested in older Chrome releases, and see where the split happens.