### PR TITLE
Use webkitRequestAnimationFrame to detect webkit since webkitMarquee is ...

### DIFF
--- a/detect-zoom.js
+++ b/detect-zoom.js
@@ -253,11 +253,11 @@
             func = ie10;
         }
         //Mobile Webkit
-        else if ('orientation' in window && typeof document.body.style.webkitMarquee === 'string') {
+        else if ('orientation' in window && 'webkitRequestAnimationFrame' in window) {
             func = webkitMobile;
         }
         //WebKit
-        else if (typeof document.body.style.webkitMarquee === 'string') {
+        else if ('webkitRequestAnimationFrame' in window) {
             func = webkit;
         }
         //Opera


### PR DESCRIPTION
...gone in the Chrome betas.

document.body.style.webkitMarquee can be expected to be gone soon in release version as well.
