### PR TITLE
Fix bug in iOS safari where zoom is always 0

### DIFF
--- a/detect-zoom.js
+++ b/detect-zoom.js
@@ -90,7 +90,7 @@
 	*/
     var safari= function()
     {
-    	var zoom = Math.round(((window.outerWidth) / window.innerWidth)*100) / 100;
+    	var zoom = Math.round(((document.documentElement.clientWidth) / window.innerWidth)*100) / 100;
         return {
             zoom: zoom,
             devicePxPerCssPx: zoom * devicePixelRatio()


### PR DESCRIPTION
In iOS 8 and 8.1 the zoom level was reported as 0, no matter what the actual zoom was.

`window.outerWidth` was breaking the formula, being constant 0 on that models. So I replaced it with `document.documentElement.clientWidth` as [suggested on StackOverflow](http://stackoverflow.com/questions/6163174/detect-page-zoom-change-with-jquery-in-safari).

I also tested on Desktop Safari 7 and 8, but didn't have the possibility to check on older iOS versions.